### PR TITLE
Mac OS X port

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,35 @@ Prerequisites for all platforms
 ===============================
 
  * CMake 2.8.0 or later
- * GTest
+ * GTest (Google C++ Testing Framework, optional)
+
+Mac OS X
+========
+
+ * XCode
+ * CMake (install using homebrew or MacPorts)
+
+To build without tests; open a terminal, then:
+```
+ $ mkdir build
+ $ cd build
+ $ cmake ..
+ $ make
+````
+
+If tests should be built, add path to gtest install like this:
+```
+ $ cmake .. -DGTEST_ROOT=~/gtest-1.7.0
+```
+
+CMake do support different generators. To create a Xcode project use the Xcode generator like this:
+```
+ $ cmake cmake -G Xcode ..
+```
+CMake have now created a Xcode project file that can be opened:
+```
+ $ open SOEM.xcodeproj
+```
 
 Windows
 =======
@@ -14,16 +42,18 @@ Windows
  * Visual Studio 2013 or later
 
 Start a developer command prompt, then:
-
+```
  $ mkdir build
  $ cd build
  $ cmake .. -DPCAP_ROOT_DIR=p:/WpdPack/ -DGTEST_ROOT=p:/gtest-1.7.0
  $ msbuild SOEM.sln
+```
 
 To build NSIS installer:
-
+```
  $ set PATH=%PATH%;p:\nsis
  $ msbuild PACKAGE.vcxproj
+```
 
 Cygwin
 ======
@@ -31,20 +61,24 @@ Cygwin
  * WinPCAP developer's pack
  * GCC 4.6 or later
 
+```
  $ mkdir build
  $ cd build
  $ cmake .. -DPCAP_ROOT_DIR=~/WpdPack -DGTEST_ROOT=~/gtest-1.7.0
  $ make
+````
 
 Linux
 =====
 
  * GCC 4.6 or later
 
+```
  $ mkdir build
  $ cd build
  $ cmake .. -DPCAP_ROOT_DIR=~/WpdPack -DGTEST_ROOT=~/gtest-1.7.0
  $ make
+````
 
 rt-kernel
 =========
@@ -54,11 +88,13 @@ rt-kernel
 
 Start a command prompt, then:
 
+```
  $ mkdir build
  $ cd build
  $ export RTK=/p/rt-kernel-src
  $ export BSP=integrator
  $ cmake -DCMAKE_TOOLCHAIN_FILE=/p/cmake/toolchain/rt-kernel-arm9e.cmake .. -G "Unix Makefiles" -DGTEST_ROOT=/p/gtest-1.7.0
  $ make
+```
 
 Substitute BSP and toolchain file as appropriate.

--- a/cmake/Darwin.cmake
+++ b/cmake/Darwin.cmake
@@ -1,0 +1,15 @@
+
+set(OSAL_SOURCES
+  osal/darwin/osal.c
+  osal/darwin/socket.c
+  )
+set(OSAL_INCLUDES
+  osal/darwin
+  )
+set(OSAL_LIBS
+  ""
+  )
+
+# set(CMAKE_C_FLAGS "-Wall -Wextra -Wno-unused-parameter -ffunction-sections")
+# set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-parameter -ffunction-sections")
+# set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections")

--- a/cmake/Darwin.cmake
+++ b/cmake/Darwin.cmake
@@ -1,7 +1,7 @@
 
 set(OSAL_SOURCES
   osal/darwin/osal.c
-  osal/darwin/socket.c
+  osal/darwin/bpf.c
   )
 set(OSAL_INCLUDES
   osal/darwin

--- a/src/alloc.c
+++ b/src/alloc.c
@@ -1,8 +1,8 @@
 
-#include <alloc.h>
+#include "alloc.h"
 
-#include <options.h>
-#include <log.h>
+#include "options.h"
+#include "log.h"
 
 #include <string.h>
 

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 ec_net_t * ec_alloc_net (void);
 ec_slave_t * ec_alloc_slave (void);

--- a/src/config.c
+++ b/src/config.c
@@ -1,16 +1,16 @@
 
-#include <config.h>
+#include "config.h"
 
-#include <options.h>
-#include <log.h>
+#include "options.h"
+#include "log.h"
 
-#include <frame.h>
+#include "frame.h"
 #include <string.h>
 
 int ec_config_static (ec_net_t * net, ec_slave_config_t * cfg)
 {
    uint8_t buffer[1400];
-   ec_frame_t * frame = ec_frame_init (buffer);
+   ec_frame_t * frame;
    ec_pdu_t * pdu;
    int wkc;
    ec_slave_t * slave;

--- a/src/config.h
+++ b/src/config.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 #ifdef __cplusplus
 }

--- a/src/ec_types.h
+++ b/src/ec_types.h
@@ -10,8 +10,8 @@ extern "C"
 #include <stdint.h>
 #include <stddef.h>
 
-#include <cc.h>
-#include <osal.h>
+#include "cc.h"
+#include "osal.h"
 
 typedef struct ec_general
 {

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -1,10 +1,10 @@
 
-#include <eeprom.h>
-#include <ec_types.h>
-#include <frame.h>
+#include "eeprom.h"
+#include "ec_types.h"
+#include "frame.h"
 
-#include <options.h>
-#include <log.h>
+#include "options.h"
+#include "log.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -181,7 +181,7 @@ static int ec_eeprom_read32 (ec_net_t * net, ec_slave_t * slave, int address,
    size = (size > 4) ? 4 : size;
    memcpy (data, pdu->data, size);
 
-   return size;
+   return (int)size;
 }
 
 int ec_eeprom_read (ec_net_t * net, ec_slave_t * slave, int address,

--- a/src/eeprom.h
+++ b/src/eeprom.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 int ec_eeprom_broadcast_read (ec_net_t * net, uint16_t address, uint32_t offset);
 int ec_eeprom_read (ec_net_t * net, ec_slave_t * slave, int address, void * data, size_t size);

--- a/src/frame.c
+++ b/src/frame.c
@@ -1,9 +1,9 @@
 
-#include <frame.h>
-#include <nic.h>
+#include "frame.h"
+#include "nic.h"
 
-#include <options.h>
-#include <log.h>
+#include "options.h"
+#include "log.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -278,7 +278,7 @@ int ec_frame_txrx (ec_nic_t * nic, ec_frame_t * frame)
    int length = sizeof(ec_frame_t) + frame->length + sizeof(uint16_t);
    int result;
    ec_pdu_t * pdu;
-   ec_pdu_t * previous;
+   ec_pdu_t * previous = NULL;
    uint16_t wkc;
 
    pdu = ec_frame_first_pdu (frame);
@@ -293,6 +293,7 @@ int ec_frame_txrx (ec_nic_t * nic, ec_frame_t * frame)
    }
 
    /* Clear NEXT field of final PDU */
+   CC_ASSERT(previous != NULL);
    previous->len &= ~EC_PDU_LENGTH_NEXT;
 
    /* Set DLPDU flag */

--- a/src/frame.h
+++ b/src/frame.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 CC_PACKED_BEGIN
 typedef struct CC_PACKED ec_frame
@@ -175,7 +175,7 @@ void ec_frame_FPWR16 (ec_frame_t * frame, uint16_t adp, uint16_t ado,
 void ec_frame_FPWR32 (ec_frame_t * frame, uint16_t adp, uint16_t ado,
                       uint32_t value);
 
-#include <nic.h>
+#include "nic.h"
 int ec_frame_txrx (ec_nic_t * nic, ec_frame_t * frame);
 
 #ifdef __cplusplus

--- a/src/log.h
+++ b/src/log.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <options.h>
-#include <osal.h>
+#include "options.h"
+#include "osal.h"
 
 #define LOG_LEVEL_DEBUG   0x00
 #define LOG_LEVEL_INFO    0x01

--- a/src/net.c
+++ b/src/net.c
@@ -1,16 +1,16 @@
 
-#include <net.h>
-#include <nic.h>
+#include "net.h"
+#include "nic.h"
 
-#include <options.h>
-#include <version.h>
-#include <log.h>
-#include <osal.h>
+#include "options.h"
+#include "version.h"
+#include "log.h"
+#include "osal.h"
 
-#include <frame.h>
-#include <eeprom.h>
+#include "frame.h"
+#include "eeprom.h"
 #include <string.h>
-#include <alloc.h>
+#include "alloc.h"
 
 static void ec_net_add_slave (ec_net_t * net, ec_slave_t * slave)
 {

--- a/src/net.h
+++ b/src/net.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 #ifdef __cplusplus
 }

--- a/src/nic.h
+++ b/src/nic.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 int ec_nic_send (ec_nic_t * nic, const void * buffer, size_t size);
 int ec_nic_receive (ec_nic_t * nic, void * buffer, size_t size);

--- a/src/osal.h
+++ b/src/osal.h
@@ -9,7 +9,7 @@ extern "C"
 
 #include <stdarg.h>
 #include <stddef.h>
-#include <nic.h>
+#include "nic.h"
 
 void os_log (int type, const char * fmt, ...);
 void * os_malloc (size_t size);

--- a/src/osal/darwin/bpf.c
+++ b/src/osal/darwin/bpf.c
@@ -1,0 +1,193 @@
+
+#include "options.h"
+#include "log.h"
+#include <net/if.h>
+#include <net/bpf.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+typedef struct ec_nic
+{
+    int handle;
+    int rx_buf_size;
+} ec_nic_t;
+
+void ec_nic_show_adapters (void)
+{
+    struct if_nameindex *ids;
+    int ix;
+    
+    ids = if_nameindex();
+    for (ix = 0; ids[ix].if_index != 0; ix++)
+    {
+        printf ("%s\n", ids[ix].if_name);
+    }
+    
+    if_freenameindex (ids);
+}
+
+int ec_nic_send (ec_nic_t * nic, const void * buffer, size_t size)
+{
+    ssize_t result;
+    
+    result = write (nic->handle, buffer, size);
+    if (result < 0)
+    {
+        LOG_ERROR (EC_NIC_DEBUG, "ec_nic_send(): %s\n", strerror(errno));
+        return -1;
+    }
+    if (result != size) {
+        LOG_ERROR (EC_NIC_DEBUG, "Did not send all bytes? (%d of %d)\n", result, size);
+    }
+    
+    return (int)size;
+}
+
+int ec_nic_receive (ec_nic_t * nic, void * buffer, size_t size)
+{
+    ssize_t bytesrx;
+    char* buf = alloca(nic->rx_buf_size);
+    struct bpf_hdr* bpf_hdr = (struct bpf_hdr*)buf;
+    
+    if (ioctl(nic->handle, FIONREAD, &bytesrx) < 0) {
+        LOG_ERROR (EC_NIC_DEBUG, "ec_nic_receive(): FIONREAD: %s\n", strerror(errno));
+        return 0;
+    }
+    
+    if (bytesrx <= 0) {
+        return 0;
+    }
+    
+    /* TODO: can read() receive more than one packet frame? 
+     Perhaps not since EtherCAT is a master-slave protocol
+     and a receive filter is setup at initialization. */
+    bytesrx = read(nic->handle, buf, nic->rx_buf_size);
+    if (bytesrx == -1) {
+        LOG_ERROR (EC_NIC_DEBUG, "ec_nic_receive(): %s\n", strerror(errno));
+        return 0;
+    }
+    
+    if (bytesrx > bpf_hdr->bh_hdrlen) {
+        bytesrx -= bpf_hdr->bh_hdrlen;
+        if (bytesrx > size) {
+            bytesrx = size;
+        }
+        memcpy(buffer, &buf[bpf_hdr->bh_hdrlen], bytesrx);
+    }
+    else {
+        bytesrx = 0;
+    }
+    
+    return (int)bytesrx;
+}
+
+ec_nic_t * ec_nic_init (const char * ifname)
+{
+    static ec_nic_t nic;
+
+    struct ifreq bound_if;
+    char buf[BUFSIZ];
+    int i;
+    
+    /* Find and open BPF device */
+    for (i = 0; i < 99; i++) {
+        sprintf(buf, "/dev/bpf%i", i);
+        nic.handle = open(buf, O_RDWR);
+        if (nic.handle != -1) {
+            break;
+        }
+    }
+    if (i == 99) {
+        LOG_ERROR (EC_NIC_DEBUG, "Unable to open adapter %s\n", ifname);
+        return NULL;
+    }
+    
+    /* Associate bpf device with a physical ethernet interface */
+    strcpy(bound_if.ifr_name, ifname);
+    if (ioctl(nic.handle, BIOCSETIF, &bound_if) > 0) {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCSETIF: %s", strerror(errno));
+        return NULL;
+    }
+    LOG_INFO(EC_NIC_DEBUG, "Bound bpf device %s to physical device %s\n", buf, ifname);
+    
+    /* Activate immediate mode. In this mode, packets are delivered as they
+     arrive, rather than being buffered for efficiency. */
+    i = 1;
+    if (ioctl(nic.handle, BIOCIMMEDIATE, &i) == -1 ) {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCIMMEDIATE: %s", strerror(errno));
+        return NULL;
+    }
+    
+    /* Sets or gets the flag determining whether locally generated packets on the
+     interface should be returned by BPF.  Set to zero to see only incoming packets on the
+     interface.  Set to one to see packets originating locally and remotely on the interface.
+     This flag is initialized to one by default. */
+    i = 0;
+    if (ioctl(nic.handle, BIOCSSEESENT, &i) == -1 ) {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCSSEESENT: %s", strerror(errno));
+        return NULL;
+    }
+    
+    /* Request buffer length. When reading this length MUST be used. */
+    if (ioctl(nic.handle, BIOCGBLEN, &nic.rx_buf_size) == -1 ) {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCGBLEN: %s", strerror(errno));
+        return NULL;
+    }
+    
+    /* Create receive filter to filter out everything except EtherCAT
+     packages. tcpdump can be used to create filters.
+     See 'man 4 bpf' for details on how to create a filter.
+     
+     tcpdump -i en0 ether proto 0x88A4 -d
+     (000) ldh      [12]
+     (001) jeq      #0x88a4  jt 2  jf 3
+     (002) ret      #262144
+     (003) ret      #0
+     
+     tcpdump -i en0 ether proto 0x88A4 -dd
+     { 0x28, 0, 0, 0x0000000c },
+     { 0x15, 0, 1, 0x000088a4 },
+     { 0x6,  0, 0, 0x00040000 },
+     { 0x6,  0, 0, 0x00000000 },
+     */
+    
+    struct bpf_program bpf_program;
+    struct bpf_insn bpf_instructions[] = {
+        { 0x28, 0, 0, 0x0000000c },
+        { 0x15, 0, 1, 0x000088a4 },
+        { 0x6,  0, 0, 0x00040000 },
+        { 0x6,  0, 0, 0x00000000 },
+    };
+    
+    bpf_program.bf_len = sizeof(bpf_instructions)/sizeof(struct bpf_insn);
+    bpf_program.bf_insns = bpf_instructions;
+    if (ioctl(nic.handle, BIOCSETF, &bpf_program) < 0)
+    {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCSETF: %s", strerror(errno));
+        return NULL;
+    }
+    
+    /* Flushes the buffer of incoming packets, and resets the statistics */
+    i = 1;
+    if (ioctl(nic.handle, BIOCFLUSH, &i) == -1 ) {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCFLUSH: %s", strerror(errno));
+        return NULL;
+    }
+    
+    /* Forces the interface into promiscuous mode.  All packets, not just those destined for
+     the local host, are processed. */
+    i = 1;
+    if (ioctl(nic.handle, BIOCPROMISC, &i) == -1 ) {
+        LOG_ERROR (EC_NIC_DEBUG, "BIOCPROMISC: %s", strerror(errno));
+        return NULL;
+    }
+    
+    return &nic;
+}
+

--- a/src/osal/darwin/cc.h
+++ b/src/osal/darwin/cc.h
@@ -1,0 +1,30 @@
+
+#ifndef CC_H
+#define CC_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <assert.h>
+
+#define CC_PACKED_BEGIN
+#define CC_PACKED_END
+#define CC_PACKED       __attribute__((packed))
+
+#define CC_TO_LE32(x)   (x)
+#define CC_TO_LE16(x)   (x)
+#define CC_FROM_LE32(x) (x)
+#define CC_FROM_LE16(x) (x)
+
+#define CC_BIT(n)       (1 << n##U)
+
+#define CC_ASSERT(exp) assert (exp)
+#define CC_STATIC_ASSERT(exp) _Static_assert (exp, "")
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC_H */

--- a/src/osal/darwin/osal.c
+++ b/src/osal/darwin/osal.c
@@ -1,9 +1,11 @@
 
-#include <osal.h>
-#include <options.h>
-#include <log.h>
+#include "osal.h"
+#include "options.h"
+#include "log.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
+
 
 void os_log (int type, const char * fmt, ...)
 {
@@ -22,3 +24,9 @@ void os_log (int type, const char * fmt, ...)
    vprintf (fmt, list);
    va_end (list);
 }
+
+void * os_malloc (size_t size)
+{
+    return malloc (size);
+}
+

--- a/src/osal/darwin/osal.c
+++ b/src/osal/darwin/osal.c
@@ -1,0 +1,24 @@
+
+#include <osal.h>
+#include <options.h>
+#include <log.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+void os_log (int type, const char * fmt, ...)
+{
+   va_list list;
+
+   switch(LOG_LEVEL_GET (type))
+   {
+   case LOG_LEVEL_DEBUG: printf ("DEBUG - "); break;
+   case LOG_LEVEL_INFO: printf ("INFO - "); break;
+   case LOG_LEVEL_WARNING: printf ("WARNING - "); break;
+   case LOG_LEVEL_ERROR: printf ("ERROR - "); break;
+   default: break;
+   }
+
+   va_start (list, fmt);
+   vprintf (fmt, list);
+   va_end (list);
+}

--- a/src/sii.c
+++ b/src/sii.c
@@ -1,6 +1,6 @@
 
-#include <sii.h>
-#include <eeprom.h>
+#include "sii.h"
+#include "eeprom.h"
 
 #include <string.h>
 #include <stdio.h>

--- a/src/sii.h
+++ b/src/sii.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 #ifdef __cplusplus
 }

--- a/src/slave.c
+++ b/src/slave.c
@@ -1,9 +1,9 @@
 
-#include <slave.h>
+#include "slave.h"
 
-#include <options.h>
-#include <log.h>
-#include <osal.h>
+#include "options.h"
+#include "log.h"
+#include "osal.h"
 
 ec_slave_t * ec_slave_get_next (ec_slave_t * slave)
 {

--- a/src/slave.h
+++ b/src/slave.h
@@ -7,8 +7,8 @@ extern "C"
 {
 #endif
 
-#include <ec_api.h>
-#include <ec_types.h>
+#include "ec_api.h"
+#include "ec_types.h"
 
 #ifdef __cplusplus
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,12 @@
-
-add_executable(ec_test
-  ec_test.cpp
-  test_frame.cpp
-  test_alloc.cpp
-  )
-add_test(ec_test ec_test)
-
-# GTest
 if(GTEST_ROOT)
+	add_executable(ec_test
+	  ec_test.cpp
+	  test_frame.cpp
+	  test_alloc.cpp
+	  )
+	add_test(ec_test ec_test)
+
+	# GTest
 	message (STATUS "Building with Google C++ Testing Framework at ${GTEST_ROOT}")
 	add_subdirectory(${GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
 	include_directories(${GTEST_ROOT}/include ${OSAL_INCLUDES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,10 @@ add_executable(ec_test
 add_test(ec_test ec_test)
 
 # GTest
-add_subdirectory(${GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
-include_directories(${GTEST_ROOT}/include ${OSAL_INCLUDES})
-target_link_libraries(ec_test gtest gtest_main soem)
+if(GTEST_ROOT)
+	message (STATUS "Building with Google C++ Testing Framework at ${GTEST_ROOT}")
+	add_subdirectory(${GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
+	include_directories(${GTEST_ROOT}/include ${OSAL_INCLUDES})
+	target_link_libraries(ec_test gtest gtest_main soem)
+endif()
+


### PR DESCRIPTION
Port to Mac OS X = added cmake configuration "darwin".
Other minor fixes;
- some type casts, inits, etc.
- local includes should be declared using "" instead of <> (which searches the system includes first)
- gtest not longer mandatory.
